### PR TITLE
added a reload for batch jobs as they are now dynamic

### DIFF
--- a/luigi/worker.py
+++ b/luigi/worker.py
@@ -886,6 +886,11 @@ class Worker(object):
             batch_tasks = filter(None, [
                 self._scheduled_tasks.get(batch_id) for batch_id in r['batch_task_ids']])
             self._batch_running_tasks[task_id] = batch_tasks
+            self._scheduled_tasks[task_id] = \
+                    load_task(module=r.get('task_module'),
+                              task_name=r['task_family'],
+                              params_str=r['task_params'])
+
 
         return GetWorkResponse(
             task_id=task_id,

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.7.3+affirm.1.0.2',
+    version='2.7.3+affirm.1.0.3',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',


### PR DESCRIPTION
This is what I had done the very first time.... whomp whomp.  But this in inside the worker process about to execute the task reloads the task into the _scheduled_tasks using the parameter string from the scheduler.