### PR TITLE
Handle config python2/3 compatibility

### DIFF
--- a/luigi/configuration.py
+++ b/luigi/configuration.py
@@ -33,6 +33,7 @@ import logging
 import os
 import warnings
 
+from configparser import Interpolation
 try:
     from ConfigParser import ConfigParser, NoOptionError, NoSectionError
 except ImportError:
@@ -40,6 +41,10 @@ except ImportError:
 
 
 class LuigiConfigParser(ConfigParser):
+
+    # for python2/3 compatibility
+    _DEFAULT_INTERPOLATION = Interpolation()
+
     NO_DEFAULT = object()
     _instance = None
     _config_paths = [

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.7.3+affirm.1.0.3',
+    version='2.7.3+affirm.1.0.4',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',


### PR DESCRIPTION
In thne python 2 config parser only strings starting with `%(` are interpolated, but in python 3 any `%` is attempted to be interpolated. Without this revision we would have to escape every single `%` in all of our configs.

This does nothing in python 2 but [overrides this](https://github.com/python/cpython/blob/3.7/Lib/configparser.py#L1192) in python 3.

Successfully tested on stage.