### PR TITLE
bump tornado again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='alexyu-tornado-bump',
+    version='2.7.5+affirm.1.4.4',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ with open('README.rst') as fobj:
     long_description = readme_note + fobj.read()
 
 install_requires = [
-    'tornado>=4.0,<5.0.1',
+    'tornado>=4.0,<=5.1.0',
     'python-daemon<3.0',
     'enum34>1.1.0 ; python_version < "3.4"'
 ]
@@ -52,7 +52,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.7.5+affirm.1.4.4',
+    version='alexyu-tornado-bump',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',


### PR DESCRIPTION
need  at least `tornado==5.1.0` for dask dashboard to work properly. since this is only going to affect client side luigi, i was just going to re-upload this as the same version (i.e. `luigi==2.7.5+affirm.1.4.4`) so i don't need to open another PR bumping luigi for all DTs again