### PR TITLE
[BDX-67] Add constant to S3Client

### DIFF
--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -94,6 +94,7 @@ class S3Client(FileSystem):
     """
 
     _s3 = None
+    uses_boto3 = True
 
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None,
                  **kwargs):
@@ -105,7 +106,6 @@ class S3Client(FileSystem):
             options['aws_secret_access_key'] = aws_secret_access_key
 
         self._options = options
-        self.uses_boto3 = True
 
     @property
     def s3(self):

--- a/luigi/contrib/s3.py
+++ b/luigi/contrib/s3.py
@@ -105,6 +105,7 @@ class S3Client(FileSystem):
             options['aws_secret_access_key'] = aws_secret_access_key
 
         self._options = options
+        self.uses_boto3 = True
 
     @property
     def s3(self):

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ if os.environ.get('READTHEDOCS', None) == 'True':
 
 setup(
     name='luigi',
-    version='2.7.5+affirm.1.4.8',
+    version='2.7.5+affirm.1.4.9',
     description='Workflow mgmgt + task scheduling + dependency resolution',
     long_description=long_description,
     author='The Luigi Authors',


### PR DESCRIPTION
in `luigi==2.7.5+affirm.1.4.8`, S3Client was previously upgraded to boto3: [PR here](https://github.com/Affirm/luigi/pull/26/files). 2 AffirmS3Clients in the all-the-things repo -- [toolbox2/luigi](https://github.com/Affirm/all-the-things/blob/5012bfa665a8d479bbf0aa8913f73196ce8c8c26/toolbox2/luigi/affirm/toolbox2/luigi/s3.py#L22) and [toolbox.affirmluigi2](https://github.com/Affirm/all-the-things/blob/28d03ce77736ef1a5ad3befa231b3cb3799ba3de/toolbox/affirm/toolbox/affirmluigi2/targets/s3.py#L20) -- will also need to be updated alongside any luigi package upgrade. a `uses_boto3` constant is added to the S3Client version upgrade so that any changes to AffirmS3Clients will be limited only to DTs upgrading luigi.

